### PR TITLE
Add support for specifying a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,13 @@ Statamic Gist Plugin
 Quick embed any [Gist](https://gist.github.com/) with a simple tag. Example:
     
     {{ gist:12345 }}
+    
+Longhand format example:
+
+		{{ gist id="12345" }}
 
 Where '12345' is the id of the desired gist. That's all there is to it.
+
+To speficy a specific file within a gist use the longhand format.
+
+		{{ gist id="12345" file="filename.md" }}

--- a/pi.gist.php
+++ b/pi.gist.php
@@ -7,9 +7,16 @@ class Plugin_gist extends Plugin {
     'author'     => 'Jack McDade',
     'author_url' => 'http://jackmcdade.com'
   );
-
+  
   static public function __callStatic($method, $args) {
     return "<script src=\"http://gist.github.com/{$method}.js\"></script>";
+  }
+
+  public function index() {
+  	$id = $this->fetch_param('id', '');
+  	$file = $this->fetch_param('file', '');
+  	
+    return "<script src=\"http://gist.github.com/{$id}.js" . ($file == '' ? '' : '?file=' . $file) . "\"></script>";
   }
 
 }


### PR DESCRIPTION
I also added a longhand format to be able to pass the file argument. The shorthand format was not passing it through.

```
{{ gist:12345 file="filename.md" }}
```

did not work, but

```
{{ gist id="12345" file="filename.md" }}
```

does.
