### PR TITLE
Swapped fetch_param for fetchPram

### DIFF
--- a/pi.gist.php
+++ b/pi.gist.php
@@ -3,19 +3,19 @@ class Plugin_gist extends Plugin {
 
   var $meta = array(
     'name'       => 'Gist',
-    'version'    => '0.9',
+    'version'    => '0.9.1',
     'author'     => 'Jack McDade',
     'author_url' => 'http://jackmcdade.com'
   );
-  
+
   static public function __callStatic($method, $args) {
     return "<script src=\"http://gist.github.com/{$method}.js\"></script>";
   }
 
   public function index() {
-  	$id = $this->fetch_param('id', '');
-  	$file = $this->fetch_param('file', '');
-  	
+  	$id = $this->fetchParam('id', '');
+  	$file = $this->fetchParam('file', '');
+
     return "<script src=\"http://gist.github.com/{$id}.js" . ($file == '' ? '' : '?file=' . $file) . "\"></script>";
   }
 


### PR DESCRIPTION
Replaced use of the deprecated fetch_param method for the shiny new fetchParam
